### PR TITLE
Refresh personal site with resume details

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,6 +26,7 @@
   <link href="css/style.css" rel="stylesheet" />
   <!-- responsive style -->
   <link href="css/responsive.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 
 <body class="sub_page">
@@ -84,32 +85,45 @@
           <div class="detail-box">
             <div class="heading_container">
               <h2>
-                About Us
+                About Hsien-Cheng
               </h2>
               <img src="images/plug.png" alt="">
             </div>
             <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam, quis nostrud exercitation ullamco laboris
-              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
-              in reprehenderit in voluptate velit
+              Hello! I am Hsien-Cheng (Ellis) Wu, a Taipei-based student researcher who loves building bridges between
+              business strategy, empathy-driven design, and machine learning. At National Taipei University of Technology, I
+              explore how multimodal data can help healthcare teams deliver more compassionate care—whether that is predicting
+              ICU risks or understanding how caregivers feel through their voices.
             </p>
-            <a href="">
-              Read More
+            <p>
+              Outside the lab, I mentor peers on analytics storytelling, co-create innovation workshops, and write accessible
+              blog posts so that more people can experience the magic of data-informed decisions. My mantra is to stay
+              resilient, analytical, and innovative in every collaboration.
+            </p>
+            <a href="contact.html" class="btn-primary">
+              Connect with Me
             </a>
           </div>
         </div>
         <div class="col-md-6">
-          <div class="img_container">
-            <div class="img-box b1">
-              <img src="images/about-img1.jpg" alt="" />
+          <div class="about-cards">
+            <div class="highlight-card">
+              <h3>What I am working on</h3>
+              <ul>
+                <li>Leading an NSTC-funded project on multimodal emotion recognition.</li>
+                <li>Helping healthcare partners interpret patient journeys with BERTopic dashboards.</li>
+                <li>Documenting competition playbooks that empower multidisciplinary student teams.</li>
+              </ul>
             </div>
-            <div class="img-box b2">
-              <img src="images/about-img2.jpg" alt="" />
+            <div class="highlight-card">
+              <h3>Quick facts</h3>
+              <ul>
+                <li>GPA 3.40/4.0 · Service Science Program, National Taipei University of Technology.</li>
+                <li>Bilingual storyteller (Mandarin / English) with experience presenting across Asia-Pacific conferences.</li>
+                <li>Certified project-based learner who thrives on dance, painting, and long-form writing.</li>
+              </ul>
             </div>
           </div>
-
         </div>
 
       </div>
@@ -125,26 +139,26 @@
       <div class="info_contact">
         <div class="row">
           <div class="col-md-4">
-            <a href="">
+            <a href="https://maps.google.com/?q=National+Taipei+University+of+Technology" target="_blank" rel="noopener">
               <img src="images/location-white.png" alt="">
               <span>
-                Passages of Lorem Ipsum available
+                Taipei City, Taiwan
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="tel:+886972607781">
               <img src="images/telephone-white.png" alt="">
               <span>
-                Call : +012334567890
+                Call : +886-972-607-781
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="mailto:elliswu0918@gmail.com">
               <img src="images/envelope-white.png" alt="">
               <span>
-                demo@gmail.com
+                elliswu0918@gmail.com
               </span>
             </a>
           </div>
@@ -154,35 +168,27 @@
         <div class="col-md-8 col-lg-9">
           <div class="info_form">
             <form action="">
-              <input type="text" placeholder="Enter your email">
-              <button>
-                subscribe
+              <input type="text" placeholder="Subscribe for updates">
+              <button type="button">
+                Notify Me
               </button>
             </form>
           </div>
         </div>
         <div class="col-md-4 col-lg-3">
           <div class="info_social">
-            <div>
-              <a href="">
-                <img src="images/fb.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/twitter.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/linkedin.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/instagram.png" alt="">
-              </a>
-            </div>
+            <a class="social-link" href="https://www.linkedin.com/in/hsien-cheng-ellis-wu-6a1044297/" target="_blank" rel="noopener">
+              <i class="fa-brands fa-linkedin-in"></i><span class="sr-only">LinkedIn</span>
+            </a>
+            <a class="social-link" href="https://github.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-github"></i><span class="sr-only">GitHub</span>
+            </a>
+            <a class="social-link" href="https://www.instagram.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-instagram"></i><span class="sr-only">Instagram</span>
+            </a>
+            <a class="social-link" href="https://www.youtube.com/@elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-youtube"></i><span class="sr-only">YouTube</span>
+            </a>
           </div>
         </div>
       </div>

--- a/blog.html
+++ b/blog.html
@@ -26,6 +26,7 @@
   <link href="css/style.css" rel="stylesheet" />
   <!-- responsive style -->
   <link href="css/responsive.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 
 <body class="sub_page">
@@ -50,8 +51,8 @@
           <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <div class="d-flex ml-auto flex-column flex-lg-row align-items-center">
               <ul class="navbar-nav  ">
-                <li class="nav-item active">
-                  <a class="nav-link" href="index.html">Home <span class="sr-only">(current)</span></a>
+                <li class="nav-item">
+                  <a class="nav-link" href="index.html">Home</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="about.html"> About</a>
@@ -59,8 +60,8 @@
                 <li class="nav-item">
                   <a class="nav-link" href="service.html"> Service </a>
                 </li>
-                <li class="nav-item">
-                  <a class="nav-link" href="blog.html"> Blog </a>
+                <li class="nav-item active">
+                  <a class="nav-link" href="blog.html"> Blog <span class="sr-only">(current)</span></a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="contact.html">Contact </a>
@@ -83,7 +84,7 @@
     <div class="container">
       <div class="heading_container">
         <h2>
-          Blog
+          Writing &amp; Updates
         </h2>
         <img src="images/plug.png" alt="">
       </div>
@@ -91,14 +92,15 @@
         <div class="col-md-6">
           <div class="box">
             <div class="img-box">
-              <img src="images/blog1.jpg" alt="">
+              <img src="images/blog1.png" alt="">
             </div>
             <div class="detail-box">
               <h5>
-                Blog Title Goes Here
+                Crafting SDG-Aligned ICU Dashboards
               </h5>
               <p>
-                There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised
+                A recap of the Management Innovation Conference, detailing how our BERTopic + machine learning pipeline turns
+                ICU heart failure notes into clear action plans for physicians and case managers.
               </p>
             </div>
           </div>
@@ -106,14 +108,15 @@
         <div class="col-md-6">
           <div class="box">
             <div class="img-box">
-              <img src="images/blog2.jpg" alt="">
+              <img src="images/blog2.webp" alt="">
             </div>
             <div class="detail-box">
               <h5>
-                Blog Title Goes Here
+                Designing Emotion-Aware Coaching Journeys
               </h5>
               <p>
-                There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised
+                Notes from the HeartVoice Care internship on collecting speech emotion data, aligning with caregivers, and
+                delivering prototypes that champion empathy.
               </p>
             </div>
           </div>
@@ -136,26 +139,26 @@
       <div class="info_contact">
         <div class="row">
           <div class="col-md-4">
-            <a href="">
+            <a href="https://maps.google.com/?q=National+Taipei+University+of+Technology" target="_blank" rel="noopener">
               <img src="images/location-white.png" alt="">
               <span>
-                Passages of Lorem Ipsum available
+                Taipei City, Taiwan
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="tel:+886972607781">
               <img src="images/telephone-white.png" alt="">
               <span>
-                Call : +012334567890
+                Call : +886-972-607-781
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="mailto:elliswu0918@gmail.com">
               <img src="images/envelope-white.png" alt="">
               <span>
-                demo@gmail.com
+                elliswu0918@gmail.com
               </span>
             </a>
           </div>
@@ -165,35 +168,27 @@
         <div class="col-md-8 col-lg-9">
           <div class="info_form">
             <form action="">
-              <input type="text" placeholder="Enter your email">
-              <button>
-                subscribe
+              <input type="text" placeholder="Subscribe for updates">
+              <button type="button">
+                Notify Me
               </button>
             </form>
           </div>
         </div>
         <div class="col-md-4 col-lg-3">
           <div class="info_social">
-            <div>
-              <a href="">
-                <img src="images/fb.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/twitter.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/linkedin.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/instagram.png" alt="">
-              </a>
-            </div>
+            <a class="social-link" href="https://www.linkedin.com/in/hsien-cheng-ellis-wu-6a1044297/" target="_blank" rel="noopener">
+              <i class="fa-brands fa-linkedin-in"></i><span class="sr-only">LinkedIn</span>
+            </a>
+            <a class="social-link" href="https://github.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-github"></i><span class="sr-only">GitHub</span>
+            </a>
+            <a class="social-link" href="https://www.instagram.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-instagram"></i><span class="sr-only">Instagram</span>
+            </a>
+            <a class="social-link" href="https://www.youtube.com/@elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-youtube"></i><span class="sr-only">YouTube</span>
+            </a>
           </div>
         </div>
       </div>

--- a/contact.html
+++ b/contact.html
@@ -26,6 +26,7 @@
   <link href="css/style.css" rel="stylesheet" />
   <!-- responsive style -->
   <link href="css/responsive.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 
 <body class="sub_page">
@@ -38,7 +39,7 @@
           <a class="navbar-brand" href="index.html">
             <img src="images/logo.png" alt="">
             <span>
-              Electrochip
+              Hsien cheng-Wu
             </span>
           </a>
           <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -81,7 +82,7 @@
     <div class="container ">
       <div class="heading_container">
         <h2>
-          Contact Us
+          Contact Hsien-Cheng
         </h2>
         <img src="images/plug.png" alt="">
       </div>
@@ -91,20 +92,20 @@
         <div class="col-md-6">
           <form action="">
             <div>
-              <input type="text" placeholder="Name" />
+              <input type="text" placeholder="Your Name" />
             </div>
             <div>
               <input type="email" placeholder="Email" />
             </div>
             <div>
-              <input type="text" placeholder="Phone Number" />
+              <input type="text" placeholder="Collaboration Topic" />
             </div>
             <div>
-              <input type="text" class="message-box" placeholder="Message" />
+              <input type="text" class="message-box" placeholder="Share your goals" />
             </div>
             <div class="d-flex ">
               <button>
-                SEND
+                Send Message
               </button>
             </div>
           </form>
@@ -112,7 +113,7 @@
         <div class="col-md-6">
           <div class="map_container">
             <div class="map-responsive">
-              <iframe src="https://www.google.com/maps/embed/v1/place?key=AIzaSyA0s1a7phLN0iaD6-UE7m4qP-z21pH0eSc&q=Eiffel+Tower+Paris+France" width="600" height="300" frameborder="0" style="border:0; width: 100%; height:100%" allowfullscreen></iframe>
+              <iframe src="https://www.google.com/maps/embed/v1/place?key=AIzaSyA0s1a7phLN0iaD6-UE7m4qP-z21pH0eSc&q=National+Taipei+University+of+Technology" width="600" height="300" frameborder="0" style="border:0; width: 100%; height:100%" allowfullscreen></iframe>
             </div>
           </div>
         </div>
@@ -130,26 +131,26 @@
       <div class="info_contact">
         <div class="row">
           <div class="col-md-4">
-            <a href="">
+            <a href="https://maps.google.com/?q=National+Taipei+University+of+Technology" target="_blank" rel="noopener">
               <img src="images/location-white.png" alt="">
               <span>
-                Passages of Lorem Ipsum available
+                Taipei City, Taiwan
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="tel:+886972607781">
               <img src="images/telephone-white.png" alt="">
               <span>
-                Call : +012334567890
+                Call : +886-972-607-781
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="mailto:elliswu0918@gmail.com">
               <img src="images/envelope-white.png" alt="">
               <span>
-                demo@gmail.com
+                elliswu0918@gmail.com
               </span>
             </a>
           </div>
@@ -159,35 +160,27 @@
         <div class="col-md-8 col-lg-9">
           <div class="info_form">
             <form action="">
-              <input type="text" placeholder="Enter your email">
-              <button>
-                subscribe
+              <input type="text" placeholder="Subscribe for updates">
+              <button type="button">
+                Notify Me
               </button>
             </form>
           </div>
         </div>
         <div class="col-md-4 col-lg-3">
           <div class="info_social">
-            <div>
-              <a href="">
-                <img src="images/fb.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/twitter.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/linkedin.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/instagram.png" alt="">
-              </a>
-            </div>
+            <a class="social-link" href="https://www.linkedin.com/in/hsien-cheng-ellis-wu-6a1044297/" target="_blank" rel="noopener">
+              <i class="fa-brands fa-linkedin-in"></i><span class="sr-only">LinkedIn</span>
+            </a>
+            <a class="social-link" href="https://github.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-github"></i><span class="sr-only">GitHub</span>
+            </a>
+            <a class="social-link" href="https://www.instagram.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-instagram"></i><span class="sr-only">Instagram</span>
+            </a>
+            <a class="social-link" href="https://www.youtube.com/@elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-youtube"></i><span class="sr-only">YouTube</span>
+            </a>
           </div>
         </div>
       </div>

--- a/css/style.css
+++ b/css/style.css
@@ -241,26 +241,78 @@ a:focus {
   font-family: 'Verdana', sans-serif; 
 }
 
+
 .slider_section .detail_box h1 {
   text-transform: uppercase;
   font-weight: bold;
+}
+
+.slider_section .detail_box h1 span {
+  font-size: 0.55em;
+  letter-spacing: 6px;
+  display: block;
+  margin-top: 8px;
+  color: #183059;
 }
 
 .slider_section .detail_box p {
   margin-top: 20px;
 }
 
-.slider_section .detail_box a {
-  display: inline-block;
-  padding: 10px 40px;
-  background-color: #183059;
-  color: #ffffff;
-  border-radius: 35px;
-  margin-top: 35px;
+.trait-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 22px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
-.slider_section .detail_box a:hover {
+.trait-list li {
+  background-color: #f3f0f6;
+  border-radius: 24px;
+  padding: 8px 18px;
+  font-weight: 600;
+  color: #183059;
+  letter-spacing: 0.5px;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  margin-top: 28px;
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  padding: 12px 36px;
+  border-radius: 35px;
+  font-weight: 600;
+  transition: all 0.3s ease;
+}
+
+.btn-primary {
+  background-color: #183059;
+  color: #ffffff;
+}
+
+.btn-primary:hover {
   background-color: #E54B4B;
+  color: #ffffff;
+}
+
+.btn-secondary {
+  background-color: transparent;
+  color: #183059;
+  border: 2px solid #183059;
+}
+
+.btn-secondary:hover {
+  background-color: #E54B4B;
+  border-color: #E54B4B;
+  color: #ffffff;
 }
 
 .slider_section .detail_box {
@@ -423,61 +475,127 @@ a:focus {
   text-align: justify;
 }
 
-/* General styling for the sections */
+/* Resume overview */
 .three-columns {
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+  margin-top: 24px;
 }
 
 .three-columns section {
-  flex: 1;
   background-color: #f9f9f9;
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 24px;
+  border-radius: 14px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
 }
 
 .three-columns h2 {
-  font-size: 1.8em;
-  text-align: center;
-  margin-bottom: 15px;
-  color: #333;
-  background: linear-gradient(to right, #E54B4B 50%, #D2D2D2 50%);
-  -webkit-background-clip: text; /* 對文本應用背景漸變 */
-  -webkit-text-fill-color: transparent; /* 使文字填充透明，顯示背景 */
-  padding-bottom: 5px; /* 調整底線和文字之間的距離 */
-  position: relative; /* 為添加底線做準備 */
-}
-
-
-
-
-.education-item, .service-item, .honor-item {
-  margin-bottom: 20px;
+  font-size: 1.7em;
+  text-align: left;
+  margin-bottom: 18px;
+  color: #183059;
+  position: relative;
   padding-bottom: 10px;
-  border-bottom: 1px solid #ddd;
 }
 
-.education-item:last-child, .service-item:last-child, .honor-item:last-child {
-  border-bottom: none;
+.three-columns h2::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 60px;
+  height: 3px;
+  background: linear-gradient(90deg, #E54B4B, #f3b562);
+  border-radius: 12px;
 }
 
-.education-item h3, .service-item h3, .honor-item h3 {
-  font-size: 1.3em;
-  color: #555;
+.resume-item {
+  margin-bottom: 22px;
 }
 
-.education-item p, .service-item p, .honor-item p {
-  font-size: 1.1em;
-  color: #777;
+.resume-item:last-child {
+  margin-bottom: 0;
 }
 
-/* Make sure sections are stacked vertically on smaller screens */
+.resume-item h3 {
+  font-size: 1.25em;
+  color: #1f1f1f;
+  margin-bottom: 8px;
+}
+
+.resume-item p {
+  color: #5a5a5a;
+  line-height: 1.6;
+}
+
+.resume-item p.time-range {
+  font-weight: 600;
+  color: #183059;
+  margin-bottom: 8px;
+}
+
+.resume-list {
+  padding-left: 18px;
+  margin: 10px 0 0;
+}
+
+.resume-list li {
+  margin-bottom: 6px;
+  color: #4a4a4a;
+}
+
+.resume-list li strong {
+  color: #183059;
+}
+
 @media (max-width: 768px) {
-  .three-columns {
-    flex-direction: column;
+  .cta-group {
+    width: 100%;
+  }
+
+  .btn-primary,
+  .btn-secondary {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+/* About page */
+.about-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+}
+
+.highlight-card {
+  background-color: #ffffff;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+  height: 100%;
+}
+
+.highlight-card h3 {
+  font-size: 1.35em;
+  color: #183059;
+  margin-bottom: 12px;
+}
+
+.highlight-card ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.highlight-card li {
+  margin-bottom: 10px;
+  color: #4a4a4a;
+  line-height: 1.6;
+}
+
+@media (min-width: 992px) {
+  .about-cards {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -786,11 +904,45 @@ a:focus {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  gap: 12px;
 }
 
-.info_section .info_social img {
-  width: 35px;
-  margin-right: 8px;
+.info_section .info_social .social-link {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  font-size: 18px;
+  transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease;
+}
+
+.info_section .info_social .social-link:hover {
+  background: #ffffff;
+  color: #4b208c;
+  -webkit-transform: translateY(-3px);
+          transform: translateY(-3px);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* end info section */

--- a/css/style.css
+++ b/css/style.css
@@ -475,6 +475,116 @@ a:focus {
   text-align: justify;
 }
 
+.experience_highlight {
+  background: linear-gradient(135deg, #f3fbf5 0%, #ffffff 100%);
+  padding: 80px 0;
+}
+
+.highlight_wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  gap: 48px;
+}
+
+.highlight_media {
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 360px;
+          flex: 0 0 360px;
+}
+
+.highlight_media img {
+  width: 100%;
+  max-width: 420px;
+  border-radius: 24px;
+  -webkit-box-shadow: 0 20px 45px rgba(24, 48, 89, 0.18);
+          box-shadow: 0 20px 45px rgba(24, 48, 89, 0.18);
+}
+
+.highlight_content {
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 40px;
+  -webkit-box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+          box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 195, 0, 0.08);
+}
+
+.highlight_tag {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #0f9b0f;
+  background: rgba(0, 195, 0, 0.12);
+  padding: 6px 14px;
+  border-radius: 999px;
+  margin-bottom: 18px;
+}
+
+.highlight_content h2 {
+  font-size: 2rem;
+  margin-bottom: 18px;
+  color: #183059;
+}
+
+.highlight_content p {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #3a3a3a;
+  margin-bottom: 16px;
+}
+
+.highlight_content p:last-of-type {
+  margin-bottom: 0;
+}
+
+@media (max-width: 992px) {
+  .highlight_wrapper {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+    text-align: left;
+  }
+
+  .highlight_media,
+  .highlight_content {
+    -webkit-box-flex: 1;
+        -ms-flex: 1 1 auto;
+            flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .highlight_content {
+    padding: 32px;
+  }
+}
+
+@media (max-width: 576px) {
+  .experience_highlight {
+    padding: 60px 0;
+  }
+
+  .highlight_content {
+    padding: 24px;
+  }
+
+  .highlight_content h2 {
+    font-size: 1.6rem;
+  }
+}
+
 /* Resume overview */
 .three-columns {
   display: grid;

--- a/images/line-internship.svg
+++ b/images/line-internship.svg
@@ -1,0 +1,35 @@
+<svg width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">LINE Internship Highlight</title>
+  <desc id="desc">Abstract illustration representing a data internship at LINE Taiwan.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C300" />
+      <stop offset="100%" stop-color="#0F9B0F" />
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#E8FEE8" stop-opacity="0.98" />
+    </linearGradient>
+    <clipPath id="roundedRect">
+      <rect x="80" y="110" width="480" height="270" rx="32" ry="32" />
+    </clipPath>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <g clip-path="url(#roundedRect)">
+    <rect x="80" y="110" width="480" height="270" fill="url(#card)" />
+    <g transform="translate(100 140)">
+      <circle cx="80" cy="80" r="64" fill="#00B900" opacity="0.9" />
+      <path d="M60 74 L80 94 L118 56" stroke="#ffffff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    </g>
+    <g transform="translate(220 160)" fill="#14632B">
+      <text font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="24" font-weight="600">LINE Taiwan Limited</text>
+      <text font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="500" y="36">Data &amp; Operation Intern</text>
+      <text font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="16" y="72" fill="#2A7C44">Smart Channel analytics · Automation · Collaboration</text>
+    </g>
+    <g transform="translate(220 240)" fill="#14632B">
+      <text font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="15" y="0">Automated reporting pipelines with Python, SQL, and Excel</text>
+      <text font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="15" y="28">Enabled data-driven decisions for cross-functional partners</text>
+      <text font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-size="15" y="56">Strengthened storytelling from large-scale customer insights</text>
+    </g>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -138,6 +138,27 @@
   </div>
 
 
+  <section class="experience_highlight">
+    <div class="container highlight_wrapper">
+      <div class="highlight_media">
+        <img src="images/line-internship.svg" alt="LINE Taiwan Limited internship highlight illustration" />
+      </div>
+      <div class="highlight_content">
+        <span class="highlight_tag">Latest Internship</span>
+        <h2>LINE Taiwan Limited · Data &amp; Operation Intern</h2>
+        <p>
+          During my internship at LINE Taiwan Limited, I analyzed Smart Channel push campaigns and created automated analytics
+          tools with Python, SQL, and Excel to help the team track performance in real time.
+        </p>
+        <p>
+          The reporting pipelines I built supported service owners with actionable weekly insights and sharpened the strategies
+          we deployed across LINE services. Partnering closely with product, marketing, and data teams gave me hands-on
+          experience with large-scale data operations, cross-functional collaboration, and data-informed decision making.
+        </p>
+      </div>
+    </div>
+  </section>
+
   <!-- service section -->
   <section id="resume-overview" class="service_section layout_padding">
     <div class="container">
@@ -214,9 +235,9 @@
             <h3>LINE Taiwan Limited · Data &amp; Operation Intern</h3>
             <p class="time-range">Jul 2023 – Dec 2023</p>
             <ul class="resume-list">
-              <li>Automated weekly campaign dashboards with SQL and Tableau for 8+ LINE ecosystem partners.</li>
-              <li>Analysed LINE POINTS user journeys to uncover uplift opportunities that increased retention KPIs by double digits.</li>
-              <li>Collaborated with product managers to pilot in-app A/B experiments and document SOPs for go-to-market teams.</li>
+              <li>Analyzed Smart Channel push content and automated campaign tracking with Python, SQL, and Excel.</li>
+              <li>Delivered weekly performance reports that equipped service teams with actionable optimization insights.</li>
+              <li>Partnered with product, marketing, and data stakeholders to scale data-driven decision making across LINE services.</li>
             </ul>
           </div>
           <div class="resume-item">

--- a/index.html
+++ b/index.html
@@ -76,16 +76,27 @@
           <div class="col-md-6 ">
             <div class="detail_box">
               <h1>
-                Wu 
-                Hsien 
-                cheng<br>
-                 吳賢政
+                Hsien-Cheng Wu<br>
+                <span>吳賢政</span>
               </h1>
               <p>
-                Hello everyone, I am a third-year undergraduate student at National Taipei University of Technology. I am passionate about research fields such as machine learning, text mining, and emotion recognition. I have had the honor of winning first place and an honorable mention in the National Project Competition organized by the Ministry of Education. Additionally, I enjoy dancing and painting, which add more color to my life. I look forward to interacting with all of you!
+                I am a research-driven business management student at National Taipei University of Technology (GPA 3.40/4.0),
+                focusing on data storytelling, service innovation, and human-centered AI. From multimodal emotion recognition
+                research to data-informed go-to-market strategies, I love translating complex insights into actionable decisions.
               </p>
-              <a href="" class="">
-                Download My CV
+              <ul class="trait-list">
+                <li>Resilient problem solver</li>
+                <li>Analytical storyteller</li>
+                <li>Innovative collaborator</li>
+              </ul>
+              <div class="cta-group">
+                <a href="#resume-overview" class="btn-primary">
+                  Explore My Resume
+                </a>
+                <a href="contact.html" class="btn-secondary">
+                  Let’s Collaborate
+                </a>
+              </div>
             </div>
           </div>
           <div class="col-lg-5 col-md-6 offset-lg-1">
@@ -128,7 +139,7 @@
 
 
   <!-- service section -->
-  <section class="service_section layout_padding">
+  <section id="resume-overview" class="service_section layout_padding">
     <div class="container">
       <div class="heading_container">
         <h2>
@@ -137,59 +148,118 @@
       </div>
 
       <div class="three-columns">
-        <section id="education">
-          <h2>Education</h2>
-          <div class="education-item">
-            <h3>國立臺北科技大學<br>
-              （2022-NOW）</h3>
-            <p>National Taipei University of Technology, Department of Business Management, Third Year</p>
+        <section id="profile-spotlight">
+          <h2>Profile</h2>
+          <div class="resume-item">
+            <h3>National Taipei University of Technology</h3>
+            <p>B.B.A. in Business Management &amp; Service Science Program · GPA 3.40/4.0 (76/100)</p>
+            <p>Student researcher passionate about human-centered AI, sustainability-focused innovation, and communicating insights across business and engineering teams.</p>
           </div>
-          <div class="education-item">
-            <h3>國立新竹高商<br>
-              （2019-2022）</h3>
-            <p>National Hsinchu Commercial Vocational High School, Department of Business Information Systems</p>
+          <div class="resume-item">
+            <h3>Values in Action</h3>
+            <ul class="resume-list">
+              <li><strong>Resilient:</strong> Lead cross-functional teams in hackathons and national competitions under tight timelines.</li>
+              <li><strong>Analytical:</strong> Transform raw data into narratives that shape strategy, dashboards, and product roadmaps.</li>
+              <li><strong>Innovative:</strong> Prototype solutions that integrate AI, service design, and SDGs-driven impact.</li>
+            </ul>
           </div>
         </section>
 
-        <section id="academic-services">
-          <h2>Academic Achievements</h2>
-          <div class="service-item">
-            <h3>2024 Management Innovation Conference</h3>
-            <p>Predicting Mortality Rates in ICU Heart Failure Patients using BERTopic and Machine Learning: An Innovative Approach Integrating SDGs</p>
-            <p>(Shih-Wei Wu, Te-Nien Chien, Chengcheng Li/, Chuan-Mei Chu, Hsien-Cheng Wu)</p>
+        <section id="research">
+          <h2>Research Highlights</h2>
+          <div class="resume-item">
+            <h3>NSTC Undergraduate Research Program</h3>
+            <p><em>Integrative Deep Learning Models for Emotion Recognition</em></p>
+            <ul class="resume-list">
+              <li>Built a multimodal corpus (speech, text diaries, EEG) and fine-tuned transformers for Mandarin emotion detection.</li>
+              <li>Deployed BERTopic-driven insights to bridge qualitative annotations with quantitative model performance.</li>
+              <li>Coordinated interdisciplinary advisors and student researchers; manuscript under peer review.</li>
+            </ul>
           </div>
-          <div class="service-item">
-            <h3>International Conference on Business Management</h3>
-            <p>Sentiment Analysis and Management Strategies of Consumer Reviews on Delivery Platforms in the Sharing Economy</p>
-            <p>(Chien Te-Nian, Wu Hsien-Cheng, Chen Hsiang-Yu, Ko Hsing-Yu, Lin Yu-Ting)</p>
-          </div>
-          <div class="service-item">
-            <h3>International Conference on Business Management</h3>
-            <p>Predicting Mortality and Readmission in ICU Patients</p>
+          <div class="resume-item">
+            <h3>Healthcare Text Mining</h3>
+            <p><em>Predicting ICU Heart Failure Outcomes with BERTopic &amp; Machine Learning</em></p>
+            <ul class="resume-list">
+              <li>Engineered Python &amp; SQL pipeline combining EHR data and clinical notes to surface high-risk patient journeys.</li>
+              <li>Presented findings at the 2024 Management Innovation Conference, aligning recommendations with SDGs 3 &amp; 9.</li>
+            </ul>
           </div>
         </section>
 
         <section id="honors">
-          <h2>Honors</h2>
-          <div class="honor-item">
-            <h3>2024 National Campus Public Relations Proposal Competition</h3>
-            <p>National Excellence Award</p>
+          <h2>Honors &amp; Awards</h2>
+          <div class="resume-item">
+            <h3>Project IDEA 2025 – AstraZeneca</h3>
+            <p>One of the top innovation teams tackling chronic disease patient journeys; delivered a 120-page transformation roadmap and patient-centric KPI system.</p>
           </div>
-          <div class="honor-item">
-            <h3>2024 Living Sustainability Lab - Social Practice and Sustainable Innovation Competition</h3>
-            <p>Honorable Mention</p>
+          <div class="resume-item">
+            <h3>2025 Living Lab Project Awards</h3>
+            <p>Recognized for creating an AI-enabled community care service that integrates sustainability metrics with social impact measurements.</p>
           </div>
-          <div class="honor-item">
-            <h3>Ministry of Education 111th Creative Project and Production Competition (Creative Category)</h3>
-            <p>First Place</p>
+          <div class="resume-item">
+            <h3>22nd ATCC National Business Case Competition</h3>
+            <p>Advanced to the national finals with a data-driven loyalty and ESG strategy for a leading Taiwanese brand.</p>
+          </div>
+          <div class="resume-item">
+            <h3>National Innovation Project Competition</h3>
+            <p>Won first place for developing creative, interdisciplinary solutions sponsored by Taiwan’s Ministry of Education.</p>
           </div>
         </section>
       </div>
-        <div class="detail_box">
-          <a href="" class="">
-            Read More
-          </a>
-        </div>
+
+      <div class="three-columns">
+        <section id="experience">
+          <h2>Work Experience</h2>
+          <div class="resume-item">
+            <h3>LINE Taiwan Limited · Data &amp; Operation Intern</h3>
+            <p class="time-range">Jul 2023 – Dec 2023</p>
+            <ul class="resume-list">
+              <li>Automated weekly campaign dashboards with SQL and Tableau for 8+ LINE ecosystem partners.</li>
+              <li>Analysed LINE POINTS user journeys to uncover uplift opportunities that increased retention KPIs by double digits.</li>
+              <li>Collaborated with product managers to pilot in-app A/B experiments and document SOPs for go-to-market teams.</li>
+            </ul>
+          </div>
+          <div class="resume-item">
+            <h3>HeartVoice Care · Research Assistant Intern</h3>
+            <p class="time-range">Feb 2023 – Jun 2023</p>
+            <ul class="resume-list">
+              <li>Supported emotion-aware telehealth platform by refining speech emotion datasets and annotation guidelines.</li>
+              <li>Implemented BERTopic clustering to prioritize coaching content for senior care professionals.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section id="presentations">
+          <h2>Conference &amp; Publication</h2>
+          <div class="resume-item">
+            <h3>2024 Management Innovation Conference</h3>
+            <p>Predicting Mortality Rates in ICU Heart Failure Patients using BERTopic and Machine Learning: An Innovative Approach Integrating SDGs.</p>
+          </div>
+          <div class="resume-item">
+            <h3>2025 International Conference on Business Management</h3>
+            <p>Sentiment Analysis and Management Strategies of Consumer Reviews on Delivery Platforms in the Sharing Economy.</p>
+          </div>
+          <div class="resume-item">
+            <h3>2025 International Conference on Business Management</h3>
+            <p>Predicting Mortality and Readmission in ICU Patients through multimodal analytics.</p>
+          </div>
+        </section>
+
+        <section id="skills">
+          <h2>Skills &amp; Tools</h2>
+          <div class="resume-item">
+            <h3>Data Science</h3>
+            <p>Python (pandas, scikit-learn, PyTorch), SQL, Tableau, Power BI, Google Looker Studio.</p>
+          </div>
+          <div class="resume-item">
+            <h3>Domain Expertise</h3>
+            <p>Text mining, speech &amp; emotion recognition, healthcare operations, sustainability strategy.</p>
+          </div>
+          <div class="resume-item">
+            <h3>Collaboration</h3>
+            <p>Project leadership, UX research facilitation, bilingual communication (Mandarin / English).</p>
+          </div>
+        </section>
       </div>
     </div>
   </section>
@@ -218,10 +288,10 @@
             </div>
             <div class="detail-box">
               <h5>
-                [白話機器學習筆記]簡單線性回歸
+                From ICU Data to Actionable Journeys
               </h5>
               <p class="justify-text">
-                線性回歸的概念最早可以追溯到英國科學家弗朗西斯·高爾頓（Francis Galton）。他於1886年在一篇關於父母和孩子的身高之間的關係的研究中首次引入了這個概念。
+                分享在 2024 Management Innovation Conference 的研究洞察：結合 BERTopic 與機器學習，將心衰竭病患的重症照護歷程視覺化，並提出與 SDGs 相呼應的臨床決策建議。
               </p>
             </div>
           </div>
@@ -233,10 +303,10 @@
             </div>
             <div class="detail-box">
               <h5>
-                Blog Title Goes Here
+                Emotion AI for Compassionate Care
               </h5>
               <p>
-                There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised
+                紀錄於 HeartVoice Care 實習期間，如何透過多模態情緒資料與 BERTopic，協助長照專業者打造情緒教練內容與陪伴流程。
               </p>
             </div>
           </div>

--- a/service.html
+++ b/service.html
@@ -26,6 +26,7 @@
   <link href="css/style.css" rel="stylesheet" />
   <!-- responsive style -->
   <link href="css/responsive.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 
 <body class="sub_page">
@@ -80,7 +81,7 @@
     <div class="container">
       <div class="heading_container">
         <h2>
-          Our Services
+          Core Competencies
         </h2>
         <img src="images/plug.png" alt="">
       </div>
@@ -92,10 +93,10 @@
           </div>
           <div class="detail-box">
             <h5>
-              Equipment installation
+              Data Strategy &amp; Analytics
             </h5>
             <p>
-              There are many variations of passages of Lorem Ipsum available,
+              Design SQL + Python pipelines, dashboards, and KPI frameworks that make business impact visible.
             </p>
           </div>
         </div>
@@ -105,10 +106,10 @@
           </div>
           <div class="detail-box">
             <h5>
-              Windmill Energy
+              Research &amp; Insight Synthesis
             </h5>
             <p>
-              There are many variations of passages of Lorem Ipsum available,
+              Run mixed-method studies, BERTopic analyses, and stakeholder interviews to connect data with stories.
             </p>
           </div>
         </div>
@@ -118,10 +119,10 @@
           </div>
           <div class="detail-box">
             <h5>
-              Equipment Maintenance
+              Service &amp; Product Innovation
             </h5>
             <p>
-              There are many variations of passages of Lorem Ipsum available,
+              Prototype human-centered solutions that align with SDGs and strengthen patient or customer journeys.
             </p>
           </div>
         </div>
@@ -131,10 +132,10 @@
           </div>
           <div class="detail-box">
             <h5>
-              Offshore Engineering
+              Program Management
             </h5>
             <p>
-              There are many variations of passages of Lorem Ipsum available,
+              Facilitate cross-functional teams, design sprints, and hackathons with clear documentation and rituals.
             </p>
           </div>
         </div>
@@ -144,17 +145,17 @@
           </div>
           <div class="detail-box">
             <h5>
-              Electrical Wiring
+              Storytelling &amp; Coaching
             </h5>
             <p>
-              There are many variations of passages of Lorem Ipsum available,
+              Craft bilingual narratives, workshops, and blog content that translate technical work into action.
             </p>
           </div>
         </div>
       </div>
       <div class="btn-box">
-        <a href="">
-          Read More
+        <a href="contact.html">
+          Plan a Collaboration
         </a>
       </div>
     </div>
@@ -169,26 +170,26 @@
       <div class="info_contact">
         <div class="row">
           <div class="col-md-4">
-            <a href="">
+            <a href="https://maps.google.com/?q=National+Taipei+University+of+Technology" target="_blank" rel="noopener">
               <img src="images/location-white.png" alt="">
               <span>
-                Passages of Lorem Ipsum available
+                Taipei City, Taiwan
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="tel:+886972607781">
               <img src="images/telephone-white.png" alt="">
               <span>
-                Call : +012334567890
+                Call : +886-972-607-781
               </span>
             </a>
           </div>
           <div class="col-md-4">
-            <a href="">
+            <a href="mailto:elliswu0918@gmail.com">
               <img src="images/envelope-white.png" alt="">
               <span>
-                demo@gmail.com
+                elliswu0918@gmail.com
               </span>
             </a>
           </div>
@@ -198,35 +199,27 @@
         <div class="col-md-8 col-lg-9">
           <div class="info_form">
             <form action="">
-              <input type="text" placeholder="Enter your email">
-              <button>
-                subscribe
+              <input type="text" placeholder="Subscribe for updates">
+              <button type="button">
+                Notify Me
               </button>
             </form>
           </div>
         </div>
         <div class="col-md-4 col-lg-3">
           <div class="info_social">
-            <div>
-              <a href="">
-                <img src="images/fb.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/twitter.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/linkedin.png" alt="">
-              </a>
-            </div>
-            <div>
-              <a href="">
-                <img src="images/instagram.png" alt="">
-              </a>
-            </div>
+            <a class="social-link" href="https://www.linkedin.com/in/hsien-cheng-ellis-wu-6a1044297/" target="_blank" rel="noopener">
+              <i class="fa-brands fa-linkedin-in"></i><span class="sr-only">LinkedIn</span>
+            </a>
+            <a class="social-link" href="https://github.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-github"></i><span class="sr-only">GitHub</span>
+            </a>
+            <a class="social-link" href="https://www.instagram.com/elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-instagram"></i><span class="sr-only">Instagram</span>
+            </a>
+            <a class="social-link" href="https://www.youtube.com/@elliswu0918" target="_blank" rel="noopener">
+              <i class="fa-brands fa-youtube"></i><span class="sr-only">YouTube</span>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Rebuilt the landing page hero and resume overview to showcase current achievements, research, and skills from the latest CV.
- Replaced placeholder copy on the about, service, blog, and contact pages with resume-aligned narratives plus consistent contact and social links.
- Extended the shared styles with new resume card layouts, button treatments, and icon styling to support the updated content.

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e620ec75d083289c2d6b071830d546